### PR TITLE
Fix: Point Xposed API dependency to local JAR

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -148,8 +148,8 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.0") // Added kotlinx-datetime
 
     // Xposed Framework
-    compileOnly("de.robv.android.xposed:api:82") // Added Xposed API dependency
-    // compileOnly(files("libs/xposed-api-82.jar")) // Kept commented as file doesn't exist
+    // compileOnly("de.robv.android.xposed:api:82") // Commented out remote Xposed API dependency
+    compileOnly(files("libs/xposed-api-82.jar")) // Using local JAR
 
     // LSPosed specific
     compileOnly("org.lsposed.hiddenapibypass:hiddenapibypass:6.1") {


### PR DESCRIPTION
I've changed app/build.gradle.kts to use compileOnly(files("libs/xposed-api-82.jar")) for the Xposed API. This requires the xposed-api-82.jar to be present in the app/libs directory.

This change is to resolve build failures where the Xposed API could not be found in remote repositories.