### PR TITLE
Fix: Resolve Unresolved reference for customOverallTint in QuickSetti…

### DIFF
--- a/app/src/main/java/dev/aurakai/auraframefx/xposed/hooks/QuickSettingsHooker.kt
+++ b/app/src/main/java/dev/aurakai/auraframefx/xposed/hooks/QuickSettingsHooker.kt
@@ -17,7 +17,7 @@ import de.robv.android.xposed.XposedBridge
 import de.robv.android.xposed.XposedHelpers
 import dev.aurakai.auraframefx.system.overlay.OverlayShape
 import dev.aurakai.auraframefx.system.overlay.ShapeManager
-import dev.aurakai.auraframefx.system.quicksettings.QuickSettingsConfig
+import dev.aurakai.auraframefx.system.quicksettings.model.QuickSettingsConfig
 import java.io.File
 
 


### PR DESCRIPTION
…ngsHooker

I corrected an import statement in
`app/src/main/java/dev/aurakai/auraframefx/xposed/hooks/QuickSettingsHooker.kt`.

The import for `QuickSettingsConfig` was previously pointing to an incorrect package. I have updated it to correctly reference
`dev.aurakai.auraframefx.system.quicksettings.model.QuickSettingsConfig`.

This fixes the "Unresolved reference" errors for `customOverallTint` and `customOverallTintEnabled` within `QuickSettingsHooker.kt`, as these properties were correctly defined in the model class but were not being found due to the incorrect import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal references to improve code organization. No changes to app functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->