### PR TITLE
Fix: Correct OpenAPI spec validation and ensure successful client gen…

### DIFF
--- a/api-spec/aura-framefx-api.yaml
+++ b/api-spec/aura-framefx-api.yaml
@@ -583,31 +583,7 @@ components:
       required:
         - taskId
         - status
-
-  # Common Responses
-  responses:
-    BadRequestError:
-      description: Invalid request format or parameters
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-    
-    UnauthorizedError:
-      description: Authentication credentials were missing or incorrect
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-    
-    RateLimitError:
-      description: Rate limit exceeded
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-    
-    ErrorResponse:
+    ApiError: # This is the schema definition key to be renamed
       type: object
       properties:
         error:
@@ -626,3 +602,26 @@ components:
               example: {"field": "email", "issue": "invalid_format"}
       required:
         - error
+
+  # Common Responses
+  responses:
+    BadRequestError:
+      description: Invalid request format or parameters
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiError'
+    
+    UnauthorizedError:
+      description: Authentication credentials were missing or incorrect
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiError'
+    
+    RateLimitError:
+      description: Rate limit exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiError'


### PR DESCRIPTION
…eration

This commit addresses validation errors in the OpenAPI specification (`api-spec/aura-framefx-api.yaml`) that prevented successful client code generation by the Gradle plugin.

Key changes to `api-spec/aura-framefx-api.yaml`:
- Resolved a validation error by removing an incorrectly defined `ErrorResponse` from under `components.responses`.
- Addressed a subsequent validation error ("not of type schema") by renaming the schema originally defined as `components.schemas.ErrorResponse` to `components.schemas.ApiError`.
- Updated all `$ref` instances in `components.responses` (e.g., for `BadRequestError`, `UnauthorizedError`, `RateLimitError`) to point to the newly named `#/components/schemas/ApiError`.

These changes ensure that the `:app:openApiGenerate` Gradle task completes successfully, allowing the Kotlin API client to be generated without errors from the specification.

The overall build process still requires you to correctly configure the Android SDK in your local environment (via ANDROID_HOME or sdk.dir in local.properties).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the API specification to rename the error response schema to `ApiError` and revised related error responses for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->