### PR TITLE
Fix: Update appAuthRedirectScheme to auraframefxbeta

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,7 @@ android {
 
         // Enable multidex support
         multiDexEnabled = true
+        manifestPlaceholders["appAuthRedirectScheme"] = "auraframefxbeta"
     }
 
     buildTypes {


### PR DESCRIPTION
I've updated the manifest placeholder for `appAuthRedirectScheme` in `app/build.gradle.kts` to "auraframefxbeta" as you requested.

This value is used by the AppAuth library for the OAuth redirect URI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Android app configuration to set a custom redirect scheme for authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->