### PR TITLE
Fix: Correct Java home for Android CI

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8 
 # Ensure that the path uses double backslashes (\\) as path separators on Windows,
 # or single forward slashes (/) on macOS and Linux.
 feat/integrate-openapi-generator
-org.gradle.java.home=/usr/local/sdkman/candidates/java/21.0.7-ms
+# org.gradle.java.home=/usr/local/sdkman/candidates/java/21.0.7-ms
 
 # Example for Windows: org.gradle.java.home=C:\\Program Files\\Java\\jdk-17
 # Example for macOS/Linux: org.gradle.java.home=/usr/lib/jvm/java-17-openjdk-amd64


### PR DESCRIPTION
The hardcoded `org.gradle.java.home` property in `gradle.properties` was causing CI builds to fail because the specified path was invalid in the CI environment.

This commit comments out the problematic line, allowing Gradle to use the JDK version configured by the `setup-java` action in the GitHub Actions workflow. This should resolve the build failures.